### PR TITLE
Add support for building wheels on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0-rc - 3.10, pypy3]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", pypy3]
 
     steps:
       - uses: actions/checkout@v2
@@ -28,3 +28,79 @@ jobs:
       - name: Run tests
         run: |
           pytest
+
+  build_binary_wheels:
+    name: ${{ matrix.os }}, arch=${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["windows-latest", "ubuntu-latest", "macOS-latest"]
+        cibw_skip: ["*-win32"]
+        arch: [auto]
+        include:
+        - os: windows-latest
+          arch: auto
+          cibw_skip: '*-win_amd64'
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v3
+    - name: Enable MSVC 64bit
+      uses: ilammy/msvc-dev-cmd@v1
+      if: matrix.os == 'windows-latest' && matrix.cibw_skip == '*-win32'
+    - name: Enable MSVC 32bit
+      uses: ilammy/msvc-dev-cmd@v1
+      if: matrix.os == 'windows-latest' && matrix.cibw_skip == '*-win_amd64'
+      with:
+        arch: x86
+    - name: Install Xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      if: matrix.os == 'macOS-latest'
+      with:
+        xcode-version: latest-stable
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+      if: runner.os == 'Linux' && matrix.arch != 'auto'
+      with:
+        platforms: all
+    - name: Build binary wheels
+      uses: pypa/cibuildwheel@v2.8.1
+      with:
+        output-dir: wheelhouse
+        config-file: pyproject.toml
+      env:
+        CIBW_BUILD_VERBOSITY: 1
+        #CIBW_TEST_COMMAND: pytest
+        CIBW_SKIP: ${{ matrix.cibw_skip }}
+        CIBW_ARCHS_LINUX: ${{ matrix.arch }}
+    - name: Show built files
+      shell: bash
+      run: ls -la wheelhouse
+    - name: Set up Python 3.8 to combine coverage Linux
+      uses: actions/setup-python@v4
+      if: runner.os == 'Linux'
+      with:
+        python-version: 3.8
+    - name: Combine coverage Linux
+      if: runner.os == 'Linux'
+      run: |-
+        echo '############ PWD'
+        pwd
+        cp .wheelhouse/.coverage* . || true
+        ls -al
+        python -m pip install coverage[toml]
+        echo '############ combine'
+        coverage combine . || true
+        echo '############ XML'
+        coverage xml -o ./tests/coverage.xml || true
+        echo '############ FIND'
+        find . -name .coverage.* || true
+        find . -name coverage.xml  || true
+    - uses: codecov/codecov-action@v3
+      name: Codecov Upload
+      with:
+        file: ./tests/coverage.xml
+    - uses: actions/upload-artifact@v3
+      name: Upload wheels artifact
+      with:
+        name: wheels
+        path: ./wheelhouse/*.whl

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,11 +52,11 @@ jobs:
       if: matrix.os == 'windows-latest' && matrix.cibw_skip == '*-win_amd64'
       with:
         arch: x86
-    - name: Install Xcode
-      uses: maxim-lobanov/setup-xcode@v1
-      if: matrix.os == 'macOS-latest'
-      with:
-        xcode-version: latest-stable
+    #- name: Install Xcode
+    #  uses: maxim-lobanov/setup-xcode@v1
+    #  if: matrix.os == 'macOS-latest'
+    #  with:
+    #    xcode-version: latest-stable
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
       if: runner.os == 'Linux' && matrix.arch != 'auto'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,16 +52,11 @@ jobs:
       if: matrix.os == 'windows-latest' && matrix.cibw_skip == '*-win_amd64'
       with:
         arch: x86
-    #- name: Install Xcode
-    #  uses: maxim-lobanov/setup-xcode@v1
-    #  if: matrix.os == 'macOS-latest'
+    #- name: Set up QEMU
+    #  uses: docker/setup-qemu-action@v2
+    #  if: runner.os == 'Linux' && matrix.arch != 'auto'
     #  with:
-    #    xcode-version: latest-stable
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
-      if: runner.os == 'Linux' && matrix.arch != 'auto'
-      with:
-        platforms: all
+    #    platforms: all
     - name: Build binary wheels
       uses: pypa/cibuildwheel@v2.8.1
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+build/
+*.egg-info/
+lark_cython/__pycache__/
+lark_cython/lark_cython.c
+lark_cython/lark_cython.*.so
+lark_cython/lark_cython.html
+__pycache__
+wheelhouse

--- a/build_wheels.sh
+++ b/build_wheels.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+__doc__="""
+Helper script to build wheels locally
+"""
+cibuildwheel --config-file pyproject.toml --platform linux --arch x86_64  

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,14 @@
 [build-system]
 requires = ["setuptools", "wheel", "Cython>=0.29.1"]
 build-backend = "setuptools.build_meta"
+
+
+[tool.cibuildwheel]
+build = "*p36-* *p37-* *p38-* *p39-* *p310-*"
+build-frontend = "build"
+#skip = "pp* *-musllinux_* *-win32"
+build-verbosity = 1
+#test-requires = [ "-r requirements/tests.txt",]
+test-requires = [ "pytest" ]
+test-command = "pytest {project}"
+#test-command = "python {project}/run_tests.py"


### PR DESCRIPTION
I found out that only the source is published to pypi and not the wheels. It shouldn't be too difficult to get cibuildwheel working on this repo and then publishing those to pypi. It will also close #2