### PR TITLE
Actions for sdist and pypi deployment

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,6 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9, "3.10", pypy3]
-
     steps:
       - uses: actions/checkout@v2
       - name: Download submodules
@@ -28,6 +27,50 @@ jobs:
       - name: Run tests
         run: |
           pytest
+
+  build_sdist:
+    name: Build source wheels
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v3
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v4.1.0
+      with:
+        python-version: 3.8
+    - name: Upgrade pip
+      run: |-
+        python -m pip install --upgrade pip
+        python -m pip install setuptools>=0.8 wheel build
+    - name: Build sdist
+      shell: bash
+      run: |-
+        python -m build --sdist --outdir wheelhouse
+    - name: Install sdist
+      run: |-
+        ls -al ./wheelhouse
+        pip install Cython
+        pip install wheelhouse/*.tar.gz -v
+    - name: Test sdist
+      run: |-
+        pwd
+        ls -al
+        # Run in a sandboxed directory
+        WORKSPACE_DNAME="testsrcdir_minimal_${CI_PYTHON_VERSION}_${GITHUB_RUN_ID}_${RUNNER_OS}"
+        mkdir -p $WORKSPACE_DNAME
+        cd $WORKSPACE_DNAME
+        # Get path to installed package
+        MOD_NAME=lark_cython
+        MOD_DPATH=$(python -c "import $MOD_NAME, os; print(os.path.dirname($MOD_NAME.__file__))")
+        echo "MOD_DPATH = $MOD_DPATH"
+        # Run the tests
+        python -m pytest --cov=$MOD_NAME $MOD_DPATH ../tests
+        cd ..
+    - name: Upload sdist artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: wheels
+        path: ./wheelhouse/*.tar.gz
 
   build_binary_wheels:
     name: ${{ matrix.os }}, arch=${{ matrix.arch }}
@@ -99,3 +142,50 @@ jobs:
       with:
         name: wheels
         path: ./wheelhouse/*.whl
+
+  publish_wheels:
+    name: Publish Wheels
+    runs-on: ubuntu-latest
+    needs:
+    - build_binary_wheels
+    - build_sdist
+
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v3
+
+    - name: Download wheels and sdist
+      uses: actions/download-artifact@v3
+      with:
+        name: wheels
+        path: wheelhouse
+
+    - name: Show files to upload
+      shell: bash
+      run: ls -la wheelhouse
+
+    ### See github action page for details
+    # https://github.com/marketplace/actions/pypi-publish
+
+    # ----
+    - name: Publish to Live PyPI
+      # Only publish real wheels for new git tags.
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        skip_existing: true
+        #repository_url: https://upload.pypi.org/legacy/  # default url should be fine
+        packages_dir: wheelhouse
+        verbose: true
+
+    # ----
+    - name: Publish to Test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      if: github.event_name == 'push' && ! startsWith(github.event.ref, 'refs/tags')
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        skip_existing: true
+        repository_url: https://test.pypi.org/legacy/
+        packages_dir: wheelhouse
+        verbose: true


### PR DESCRIPTION
Next step to hopefully get this on pypi (and letting me declare it as a dependency in my projects).

This adds two new actions to deploy to the test pypi server and to deploy to the live pypi server. There is a third new step that also builds source distributions, so any platform with a compiler can pip install this even if the wheels don't directly support it (which probably isn't too many people).

I haven't used the gh-action-pypi-publish action yet, so this may not work  (I have custom publishing logic that also signs my wheels with a CI gpg key), but it should be too hard to debug.

@erezsh To support this it would be helpful if you could generate a token for test.pypi.org (you may need to create an account if you don't have one, it's distinct from pypi.org) and then populate the `TEST_PYPI_API_TOKEN` secret with that token. When that works, you can do the same for regular pypi.

The logic is setup such authorized PRs will try to publish to test.pypi. When you want to make a release, you would generate a new git tag (which can be done via the github release process), and the live pypi action will run when it sees a new tag.