### PR TITLE
fix UnexpectedToken handling exception

### DIFF
--- a/lark_cython/lark_cython.pyx
+++ b/lark_cython/lark_cython.pyx
@@ -24,7 +24,7 @@ cdef class Token:
     cdef public end_column
     cdef public end_pos
 
-    def __cinit__(self, str type_, str value, int start_pos, int line, int column, end_line=None, end_column=None, end_pos=None):
+    def __cinit__(self, str type_, str value, int start_pos=0, int line=0, int column=0, end_line=None, end_column=None, end_pos=None):
         self.type = type_
         self.start_pos = start_pos
         self.value = value
@@ -381,6 +381,8 @@ cdef class LexerThread:
 
     def __copy__(self):
         return type(self)(self.lexer, copy(self.state))
+    
+    _Token = Token
 
 ####
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,4 +1,6 @@
+import pytest
 from lark import Lark, Tree
+from lark.exceptions import UnexpectedToken
 import lark_cython
 
 
@@ -77,3 +79,16 @@ def test_lexer_callbacks():
 	assert isinstance(res.children[0], lark_cython.Token)
 	assert isinstance(comments[0], lark_cython.Token)
 	assert len(comments) == 2
+
+def test_unexpected_token():
+	parser = Lark("""
+	    display_decimals: "DECIMALS"i WS INT
+		start: display_decimals
+	    %import common (INT, WS)
+	""", parser="lalr", _plugins=lark_cython.plugins)
+	with pytest.raises(UnexpectedToken) as err:
+		parser.parse("""
+	    	bla 
+	    	""")
+	assert str(err.value).startswith("Unexpected token Token('WS'")
+	


### PR DESCRIPTION
I don't know if this is the correct solution but it fixes the case described below

👇🏽 

with a grammar like:
```txt
display_decimals: "DECIMALS"i WS INT
start: display_decimals
%import common (INT, WS)
```
and a script like
```python3
script = """
      bla
"""
```

It raises
```
*** AttributeError: 'lark_cython.lark_cython.LexerThread' object has no attribute '_Token'
```

This PR handle the right exception when the token is wrong rather than raising an Attribute error. 	    
