### PR TITLE
Add strict to LALR_Parser

### DIFF
--- a/lark_cython/__init__.py
+++ b/lark_cython/__init__.py
@@ -1,3 +1,3 @@
 from .lark_cython import plugins, Token
 
-__version__ = "0.0.14"
+__version__ = "0.0.15"

--- a/lark_cython/lark_cython.pyx
+++ b/lark_cython/lark_cython.pyx
@@ -567,8 +567,8 @@ cdef class _Parser:
 
 
 class LALR_Parser(Serialize):
-    def __init__(self, parser_conf, debug=False):
-        analysis = LALR_Analyzer(parser_conf, debug=debug)
+    def __init__(self, parser_conf, debug=False, strict=False):
+        analysis = LALR_Analyzer(parser_conf, debug=debug, strict=strict)
         analysis.compute_lalr()
         callbacks = parser_conf.callbacks
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
 
     ext_modules = cythonize('lark_cython/*.pyx'), # accepts a glob pattern
     requires = ['Cython'],
-    install_requires = ['lark>=1.1.4', 'cython>=0.29.0', 'Cython>=0.29.0'],
+    install_requires = ['lark>=1.1.6', 'cython>=0.29.0', 'Cython>=0.29.0'],
     setup_requires=['Cython'],
 
     author = "Erez Shinan",


### PR DESCRIPTION
Fixes https://github.com/lark-parser/lark_cython/issues/23

It seems that `LALR_Analyzer` is imported from lark itself, so perhaps this patch is all that is needed?

Other changes include bumping the lark-cython version and the minimum required lark version. 