### PR TITLE
Test on multiple versions and allow newer Cython versions

### DIFF
--- a/.github/workflows/tests-versions.yml
+++ b/.github/workflows/tests-versions.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, 3.10, 3.11, 3.12, 3.13]
+        python-version: [3.9, "3.10", 3.11, 3.12, 3.13]
     steps:
     - name: Checkout source
       uses: actions/checkout@v4

--- a/.github/workflows/tests-versions.yml
+++ b/.github/workflows/tests-versions.yml
@@ -1,0 +1,51 @@
+name: Tests
+on: [push, pull_request]
+
+jobs:
+  build_sdist:
+    name: Build and test on Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.9, 3.10, 3.11, 3.12, 3.13]
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4.7.1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Upgrade pip
+      run: |-
+        python -m pip install --upgrade pip
+        python -m pip install setuptools>=0.8 wheel build
+
+    - name: Build sdist
+      shell: bash
+      run: |-
+        python -m build --sdist --outdir wheelhouse
+
+    - name: Install sdist
+      run: |-
+        ls -al ./wheelhouse
+        pip install pytest pytest-cov
+        pip install Cython
+        pip install wheelhouse/*.tar.gz -v
+
+    - name: Test sdist
+      run: |-
+        pwd
+        ls -al
+        # Run in a sandboxed directory
+        WORKSPACE_DNAME="testsrcdir_minimal_${{ matrix.python-version }}_${GITHUB_RUN_ID}_${RUNNER_OS}"
+        mkdir -p $WORKSPACE_DNAME
+        cd $WORKSPACE_DNAME
+        # Get path to installed package
+        MOD_NAME=lark_cython
+        MOD_DPATH=$(python -c "import $MOD_NAME, os; print(os.path.dirname($MOD_NAME.__file__))")
+        echo "MOD_DPATH = $MOD_DPATH"
+        # Run the tests
+        python -m pytest --cov=$MOD_NAME $MOD_DPATH ../tests
+        cd ..

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,10 +8,10 @@ jobs:
     steps:
     - name: Checkout source
       uses: actions/checkout@v4
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v4.7.1
       with:
-        python-version: 3.8
+        python-version: 3.10
     - name: Upgrade pip
       run: |-
         python -m pip install --upgrade pip
@@ -83,11 +83,11 @@ jobs:
     - name: Show built files
       shell: bash
       run: ls -la wheelhouse
-    - name: Set up Python 3.8 to combine coverage Linux
+    - name: Set up Python 3.10 to combine coverage Linux
       uses: actions/setup-python@v4.7.1
       if: runner.os == 'Linux'
       with:
-        python-version: 3.8
+        python-version: 3.10
     - name: Combine coverage Linux
       if: runner.os == 'Linux'
       run: |-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v4.7.1
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - name: Upgrade pip
       run: |-
         python -m pip install --upgrade pip
@@ -87,7 +87,7 @@ jobs:
       uses: actions/setup-python@v4.7.1
       if: runner.os == 'Linux'
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - name: Combine coverage Linux
       if: runner.os == 'Linux'
       run: |-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,7 +71,7 @@ jobs:
       with:
         arch: x86
     - name: Build binary wheels
-      uses: pypa/cibuildwheel@v2.11.3
+      uses: pypa/cibuildwheel@v2.21.3
       with:
         output-dir: wheelhouse
         config-file: pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools", "wheel", "Cython>=0.29,<0.30"]
+requires = ["setuptools", "wheel", "Cython>=3.0,<3.1"]
 build-backend = "setuptools.build_meta"
 
 
 [tool.cibuildwheel]
-build = "*p36-* *p37-* *p38-* *p39-* *p310-* *p311-*"
+build = "*p38-* *p39-* *p310-* *p311-* *p312-* *p313-*"
 build-frontend = "build"
 build-verbosity = 1
 test-requires = [ "pytest" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "Cython>=0.29.1,<0.29.35"]
+requires = ["setuptools", "wheel", "Cython>=0.29,<0.30"]
 build-backend = "setuptools.build_meta"
 
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     packages=find_packages(),
     ext_modules=cythonize("lark_cython/*.pyx"),  # accepts a glob pattern
     requires=["Cython"],
-    install_requires=["lark>=1.1.7", "cython>=0.29,<0.30", "Cython>=0.29,<0.30"],
+    install_requires=["lark>=1.1.7", "cython>=3.0,<3.1", "Cython>=3.0,<3.1"],
     setup_requires=["Cython"],
     author="Erez Shinan",
     author_email="lark@erezsh.com",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     packages=find_packages(),
     ext_modules=cythonize("lark_cython/*.pyx"),  # accepts a glob pattern
     requires=["Cython"],
-    install_requires=["lark>=1.1.7", "cython>=0.29.1,<0.29.35", "Cython>=0.29,<0.30"],
+    install_requires=["lark>=1.1.7", "cython>=0.29,<0.30", "Cython>=0.29,<0.30"],
     setup_requires=["Cython"],
     author="Erez Shinan",
     author_email="lark@erezsh.com",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     packages=find_packages(),
     ext_modules=cythonize("lark_cython/*.pyx"),  # accepts a glob pattern
     requires=["Cython"],
-    install_requires=["lark>=1.1.7", "cython>=0.29.1,<0.29.35", "Cython>=0.29.1,<0.29.35"],
+    install_requires=["lark>=1.1.7", "cython>=0.29.1,<0.29.35", "Cython>=0.29,<0.30"],
     setup_requires=["Cython"],
     author="Erez Shinan",
     author_email="lark@erezsh.com",


### PR DESCRIPTION
Python 3.8 is EOL (see https://devguide.python.org/versions/), updated main GitHub Action to 3.10.
Allow new versions of Cython to address #46. 
