### PR TITLE
Remove cython from installation 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Upload sdist artifact
       uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: wheels-src
         path: ./wheelhouse/*.tar.gz
 
   build_binary_wheels:
@@ -53,21 +53,21 @@ jobs:
     strategy:
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macOS-latest"]
-        cibw_skip: ["*-win32"]
+        cibw_skip: ["win32"]
         arch: [auto]
         include:
         - os: windows-latest
           arch: auto
-          cibw_skip: '*-win_amd64'
+          cibw_skip: 'win_amd64'
     steps:
     - name: Checkout source
       uses: actions/checkout@v4
     - name: Enable MSVC 64bit
       uses: ilammy/msvc-dev-cmd@v1
-      if: matrix.os == 'windows-latest' && matrix.cibw_skip == '*-win32'
+      if: matrix.os == 'windows-latest' && matrix.cibw_skip == 'win32'
     - name: Enable MSVC 32bit
       uses: ilammy/msvc-dev-cmd@v1
-      if: matrix.os == 'windows-latest' && matrix.cibw_skip == '*-win_amd64'
+      if: matrix.os == 'windows-latest' && matrix.cibw_skip == 'win_amd64'
       with:
         arch: x86
     - name: Build binary wheels
@@ -78,7 +78,7 @@ jobs:
       env:
         CIBW_BUILD_VERBOSITY: 1
         #CIBW_TEST_COMMAND: pytest
-        CIBW_SKIP: ${{ matrix.cibw_skip }}
+        CIBW_SKIP: "*-${{ matrix.cibw_skip }}"
         CIBW_ARCHS_LINUX: ${{ matrix.arch }}
     - name: Show built files
       shell: bash
@@ -110,8 +110,9 @@ jobs:
     - uses: actions/upload-artifact@v4
       name: Upload wheels artifact
       with:
-        name: wheels
+        name: wheels-${{ matrix.os }}-${{ matrix.cibw_skip }}
         path: ./wheelhouse/*.whl
+
 
   publish_wheels:
     name: Publish Wheels
@@ -121,6 +122,12 @@ jobs:
     - build_sdist
 
     steps:
+    - name: Merge wheels
+      uses: actions/upload-artifact/merge@v4
+      with:
+        name: wheels
+        pattern: wheels-*
+
     - name: Checkout source
       uses: actions/checkout@v4
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
         python -m pytest --cov=$MOD_NAME $MOD_DPATH ../tests
         cd ..
     - name: Upload sdist artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: wheels
         path: ./wheelhouse/*.tar.gz
@@ -107,7 +107,7 @@ jobs:
       name: Codecov Upload
       with:
         file: ./tests/coverage.xml
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       name: Upload wheels artifact
       with:
         name: wheels

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,7 +125,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Download wheels and sdist
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: wheels
         path: wheelhouse

--- a/setup.py
+++ b/setup.py
@@ -5,16 +5,7 @@ from setuptools import find_packages, setup
 
 # python .\setup.py build_ext --inplace
 
-
-# Delayed import; https://stackoverflow.com/questions/37471313/setup-requires-with-cython
-try:
-    from Cython.Build import cythonize
-except ImportError:
-
-    def cythonize(*args, **kwargs):
-        from Cython.Build import cythonize
-
-        return cythonize(*args, **kwargs)
+from Cython.Build import cythonize
 
 
 def parse_description():

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,8 @@ setup(
     packages=find_packages(),
     ext_modules=cythonize("lark_cython/*.pyx"),  # accepts a glob pattern
     requires=["Cython"],
-    install_requires=["lark>=1.1.7", "cython>=3.0,<3.1", "Cython>=3.0,<3.1"],
-    setup_requires=["Cython"],
+    install_requires=["lark>=1.1.7"],
+    setup_requires=["Cython>=3.0,<3.1"],
     author="Erez Shinan",
     author_email="lark@erezsh.com",
     description="A Lark plugin that optimizes LALR parsing using Cython",


### PR DESCRIPTION
Cython should only be necessary during build.
Installations should stay cython free (current version of cython alone takes 20MB) 